### PR TITLE
Python 2.7 and 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ env:
 - DJANGO_VERSION=1.8
 - DJANGO_VERSION=1.11
 - DJANGO_VERSION=2.0
+- DJANGO_VERSION=2.1
 matrix:
   exclude:
     - python: '2.7'
       env: 'DJANGO_VERSION=2.0'
+    - python: '2.7'
+      env: 'DJANGO_VERSION=2.1'
 install:
 - pip install -U django==$DJANGO_VERSION
 script: python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-sudo: false
+sudo: required
+dist: xenial
 python:
 - '2.7'
 - '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
 - DJANGO_VERSION=1.8
 - DJANGO_VERSION=1.11
 - DJANGO_VERSION=2.0
+matrix:
+  exclude:
+    - python: '2.7'
+      env: 'DJANGO_VERSION=2.0'
 install:
 - pip install -U django==$DJANGO_VERSION
 script: python manage.py test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ django-zen-queries
 
 Gives you control over which parts of your code are allowed to run queries, and which aren't.
 
-Tested against Django 1.8, 1.11 and 2.0 on Python 2.7, 3.5, 3.6 and 3.7
+Tested against Django 1.8, 1.11, 2.0 and 2.1 on Python 2.7, 3.5, 3.6 and 3.7
 
 ### Motivation
 

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -1,8 +1,8 @@
 from zen_queries import queries_disabled
 
 
-class QueriesDisabledSerializerMixin:
+class QueriesDisabledSerializerMixin(object):
     @property
     def data(self):
         with queries_disabled():
-            return super().data
+            return super(QueriesDisabledSerializerMixin, self).data

--- a/zen_queries/template_response.py
+++ b/zen_queries/template_response.py
@@ -5,10 +5,10 @@ from django.template.response import (
 from zen_queries import queries_disabled
 
 
-class RenderMixin:
+class RenderMixin(object):
     def render(self, *args, **kwargs):
         with queries_disabled():
-            return super().render(*args, **kwargs)
+            return super(RenderMixin, self).render(*args, **kwargs)
 
 
 class TemplateResponse(RenderMixin, DjangoTemplateResponse):

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -50,7 +50,7 @@ class TemplateResponseTestCase(TestCase):
             response.render()
 
 
-class FakeSerializer:
+class FakeSerializer(object):
     def __init__(self, queryset):
         self.queryset = queryset
 


### PR DESCRIPTION
* Go back to Python 2-style class and `super` syntax to support Python 2.7
* Add some Travis config to make Python 3.7 work (an [official workaround](https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905)).
* Add Django 2.1 to build matrix because why not?
* Exclude Django 2.0+ and Python 2.7 from the build matrix.