### PR TITLE
Add a queries-disabled version of the Django render shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Now we have exactly what we need: when a developer comes along and adds `{{ pizz
 
 As well as the context managers, the package provides some tools to make it easier to use in common situations:
 
+#### Render shortcut
+
+If you're using the Django `render` shortcut (as in the example above), to avoid having to explicitly add the context manager to every view, you can change your import `from django.shortcuts import render` to `from zen_queries import render`. All the views in that file will automatically be disallowed from running queries during template rendering.
+
 #### TemplateResponse subclass
 
 `TemplateResponse` (and `SimpleTemplateResponse`) objects are lazy, meaning that template rendering happens on the way "out" of the Django stack. `zen_queries.TemplateResponse` and `zen_queries.SimpleTemplateResponse` are subclasses of these with `queries_disabled` applied to the `render` method.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ As well as the context managers, the package provides some tools to make it easi
 
 #### Render shortcut
 
-If you're using the Django `render` shortcut (as in the example above), to avoid having to explicitly add the context manager to every view, you can change your import `from django.shortcuts import render` to `from zen_queries import render`. All the views in that file will automatically be disallowed from running queries during template rendering.
+If you're using the Django `render` shortcut (as in the example above), to avoid having to add the context manager to every view, you can change your import `from django.shortcuts import render` to `from zen_queries import render`. All the views in that file will automatically be disallowed from running queries during template rendering.
 
 #### TemplateResponse subclass
 

--- a/zen_queries/__init__.py
+++ b/zen_queries/__init__.py
@@ -3,6 +3,7 @@ from zen_queries.decorators import (
     queries_dangerously_enabled,
     QueriesDisabledError,
 )
+from zen_queries.render import render
 from zen_queries.rest_framework import QueriesDisabledSerializerMixin
 from zen_queries.template_response import TemplateResponse, SimpleTemplateResponse
 from zen_queries.utils import fetch

--- a/zen_queries/render.py
+++ b/zen_queries/render.py
@@ -1,0 +1,12 @@
+from django.shortcuts import render as django_render
+from zen_queries import queries_disabled
+
+
+def render(
+    request, template_name, context=None, content_type=None, status=None, using=None
+):
+    with queries_disabled():
+        response = django_render(
+            request, template_name, context, content_type, status, using
+        )
+    return response

--- a/zen_queries/render.py
+++ b/zen_queries/render.py
@@ -2,11 +2,11 @@ from django.shortcuts import render as django_render
 from zen_queries import queries_disabled
 
 
-def render(
-    request, template_name, context=None, content_type=None, status=None, using=None
-):
+def render(*args, **kwargs):
+    """
+    Wrapper around Django's `render` shortcut that is
+    not allowed to run database queries
+    """
     with queries_disabled():
-        response = django_render(
-            request, template_name, context, content_type, status, using
-        )
+        response = django_render(*args, **kwargs)
     return response

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -5,6 +5,7 @@ from zen_queries import (
     queries_dangerously_enabled,
     QueriesDisabledError,
     QueriesDisabledSerializerMixin,
+    render,
     SimpleTemplateResponse,
     TemplateResponse,
 )
@@ -34,6 +35,13 @@ class FetchTestCase(TestCase):
             widgets = Widget.objects.all()
             with self.assertRaises(QueriesDisabledError):
                 fetch(widgets)
+
+
+class RenderShortcutTestCase(TestCase):
+    def test_render(self):
+        widgets = Widget.objects.all()
+        with self.assertRaises(QueriesDisabledError):
+            response = render(None, "template.html", {"widgets": widgets})
 
 
 class TemplateResponseTestCase(TestCase):


### PR DESCRIPTION
This adds a version of `django.shortcuts.render` that wraps the real `render` shortcut in `queries_disabled`.