### PR TITLE
Ensure calls to disable_queries can be nested

### DIFF
--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -17,6 +17,18 @@ class ContextManagerTestCase(TestCase):
             with self.assertRaises(QueriesDisabledError):
                 Widget.objects.count()
 
+    def test_nested_queries_disabled(self):
+        with queries_disabled():
+            with self.assertRaises(QueriesDisabledError):
+                Widget.objects.count()
+            with queries_disabled():
+                with self.assertRaises(QueriesDisabledError):
+                    Widget.objects.count()
+                with queries_disabled():
+                    with self.assertRaises(QueriesDisabledError):
+                        Widget.objects.count()
+        Widget.objects.count()
+
     def test_queries_enabled(self):
         with queries_disabled():
             with queries_dangerously_enabled():


### PR DESCRIPTION
The code that applies and removes the monkeypatches was too simple, resulting in the following behaviour:

```python
with queries_disabled():
    with queries_disabled():
         print('hi')
    run_some_queries()  # <- this should raise, but doesn't
```

We now add a variable per-connection that tracks the current depth of calls to the context manager, and does nothing if the depth is greater than 0 (ie we are already inside a `queries_disabled` block). The monkeypatches are only applied the first time the context manager is called, and they are only removed when the depth gets back down to 0.