### PR TITLE
Fix behaviour of queries_dangerously_enabled

### DIFF
--- a/zen_queries/decorators.py
+++ b/zen_queries/decorators.py
@@ -10,41 +10,72 @@ def _fake(*args, **kwargs):
     raise QueriesDisabledError()
 
 
-def _apply_monkeypatch(force=False):
-    for connection in connections.all():
-        connection._zen_queries_depth = getattr(connection, "_zen_queries_depth", 0) + 1
-        if connection._zen_queries_depth == 1 or force:
-            connection._real_create_cursor = connection.create_cursor
-            connection.create_cursor = _fake
+def _apply_monkeypatch(connection):
+    connection._queries_disabled = True
+    connection._real_create_cursor = connection.create_cursor
+    connection.create_cursor = _fake
 
 
-def _remove_monkeypatch(force=False):
+def _remove_monkeypatch(connection):
+    connection.create_cursor = connection._real_create_cursor
+    del connection._real_create_cursor
+    del connection._queries_disabled
+
+
+def _disable_queries():
     for connection in connections.all():
-        if not hasattr(connection, "_zen_queries_depth"):
-            assert hasattr(
-                connection, "_real_create_cursor"
-            ), "Cannot enable queries, not currently inside a queries_disabled block"
-        connection._zen_queries_depth -= 1
-        if connection._zen_queries_depth == 0 or force:
-            connection.create_cursor = connection._real_create_cursor
-            del connection._real_create_cursor
-            if not force:
-                del connection._zen_queries_depth
+        _apply_monkeypatch(connection)
+
+
+def _enable_queries():
+    for connection in connections.all():
+        _remove_monkeypatch(connection)
+
+
+def _are_queries_disabled():
+    for connection in connections.all():
+        return hasattr(connection, "_queries_disabled")
+
+
+def _are_queries_dangerously_enabled():
+    for connection in connections.all():
+        return hasattr(connection, "_queries_dangerously_enabled")
+
+
+def _mark_as_dangerously_enabled():
+    for connection in connections.all():
+        connection._queries_dangerously_enabled = True
+
+
+def _mark_as_not_dangerously_enabled():
+    for connection in connections.all():
+        del connection._queries_dangerously_enabled
 
 
 @contextmanager
 def queries_disabled():
-    _apply_monkeypatch()
+    queries_already_disabled = _are_queries_disabled()
+    if not queries_already_disabled and not _are_queries_dangerously_enabled():
+        _disable_queries()
     try:
         yield
     finally:
-        _remove_monkeypatch()
+        if not queries_already_disabled and not _are_queries_dangerously_enabled():
+            _enable_queries()
 
 
 @contextmanager
 def queries_dangerously_enabled():
-    _remove_monkeypatch(force=True)
+    queries_dangerously_enabled_before = _are_queries_dangerously_enabled()
+    if not queries_dangerously_enabled_before:
+        _mark_as_dangerously_enabled()
+    queries_disabled_before = _are_queries_disabled()
+    if queries_disabled_before:
+        _enable_queries()
     try:
         yield
     finally:
-        _apply_monkeypatch(force=True)
+        if queries_disabled_before:
+            _disable_queries()
+        if not queries_dangerously_enabled_before:
+            _mark_as_not_dangerously_enabled()

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -40,6 +40,29 @@ class ContextManagerTestCase(TestCase):
             with queries_dangerously_enabled():
                 pass
 
+        # enabling queries should always enable them, no matter how deeply
+        # nested we are, and should restore the stack afterwards
+        with queries_disabled():
+            with queries_dangerously_enabled():
+                Widget.objects.count()
+            with queries_disabled():
+                with queries_dangerously_enabled():
+                    Widget.objects.count()
+                with queries_disabled():
+                    with queries_dangerously_enabled():
+                        Widget.objects.count()
+                    with self.assertRaises(QueriesDisabledError):
+                        Widget.objects.count()
+                with queries_dangerously_enabled():
+                    Widget.objects.count()
+                with self.assertRaises(QueriesDisabledError):
+                    Widget.objects.count()
+            with queries_dangerously_enabled():
+                Widget.objects.count()
+            with self.assertRaises(QueriesDisabledError):
+                Widget.objects.count()
+        Widget.objects.count()
+
 
 class FetchTestCase(TestCase):
     def test_fetch_all(self):

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -63,6 +63,19 @@ class ContextManagerTestCase(TestCase):
                 Widget.objects.count()
         Widget.objects.count()
 
+        # Now nest inside each other!
+        with queries_disabled():
+            with queries_dangerously_enabled():
+                with queries_disabled():
+                    with queries_dangerously_enabled():
+                        Widget.objects.count()
+                    with self.assertRaises(QueriesDisabledError):
+                        Widget.objects.count()
+                Widget.objects.count()
+            with self.assertRaises(QueriesDisabledError):
+                Widget.objects.count()
+        Widget.objects.count()
+
 
 class FetchTestCase(TestCase):
     def test_fetch_all(self):

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -35,43 +35,23 @@ class ContextManagerTestCase(TestCase):
             with queries_dangerously_enabled():
                 Widget.objects.count()
 
-        # queries can't be enabled if they've not been disabled
-        with self.assertRaises(AssertionError):
-            with queries_dangerously_enabled():
-                pass
-
-        # enabling queries should always enable them, no matter how deeply
-        # nested we are, and should restore the stack afterwards
-        with queries_disabled():
-            with queries_dangerously_enabled():
+    def test_outer_queries_enabled(self):
+        # enabling queries should always enable them, and subsequent
+        # calls to disable should do nothing
+        with queries_dangerously_enabled():
+            with queries_disabled():
                 Widget.objects.count()
+
+    def test_nested_queries_enabled(self):
+        with queries_disabled():
             with queries_disabled():
                 with queries_dangerously_enabled():
-                    Widget.objects.count()
-                with queries_disabled():
-                    with queries_dangerously_enabled():
-                        Widget.objects.count()
-                    with self.assertRaises(QueriesDisabledError):
-                        Widget.objects.count()
-                with queries_dangerously_enabled():
-                    Widget.objects.count()
+                    with queries_disabled():
+                        with queries_dangerously_enabled():
+                            with queries_disabled():
+                                Widget.objects.count()
                 with self.assertRaises(QueriesDisabledError):
                     Widget.objects.count()
-            with queries_dangerously_enabled():
-                Widget.objects.count()
-            with self.assertRaises(QueriesDisabledError):
-                Widget.objects.count()
-        Widget.objects.count()
-
-        # Now nest inside each other!
-        with queries_disabled():
-            with queries_dangerously_enabled():
-                with queries_disabled():
-                    with queries_dangerously_enabled():
-                        Widget.objects.count()
-                    with self.assertRaises(QueriesDisabledError):
-                        Widget.objects.count()
-                Widget.objects.count()
             with self.assertRaises(QueriesDisabledError):
                 Widget.objects.count()
         Widget.objects.count()


### PR DESCRIPTION
... inside nested `queries_disabled` blocks.

This test should cover all possible cases! Basically we want `queries_dangerouly_enabled` to _always_ enable queries (even if we're already nested inside several `queries_disabled` layers), but then restore things to how they were before.