### PR TITLE
Add a mixin for REST framework views

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you're using the Django `render` shortcut (as in the example above), to avoid
 
 #### Django REST framework Serializer and View mixins
 
-Django REST framework serializers are another major source of unexpected queries. Adding a field to a serializer (perhaps deep within a tree of nested serializers) can very easily cause your application to suddenly start emitting hundreds of queries. `zen_queries.rest_framework.QueriesDisabledSerializerMixin` can be applied to any serializer to wrap `queries_disabled` around the `.data` property, meaning that the serialization phase is not allowed to execute any queries. You can also add a mixin to your REST framework views, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer.
+Django REST framework serializers are another major source of unexpected queries. Adding a field to a serializer (perhaps deep within a tree of nested serializers) can very easily cause your application to suddenly start emitting hundreds of queries. `zen_queries.rest_framework.QueriesDisabledSerializerMixin` can be added to any serializer to wrap `queries_disabled` around the `.data` property, meaning that the serialization phase is not allowed to execute any queries. You can add this mixin to an existing serializer instance with `zen_queries.rest_framework.disable_serializer_queries` like this: `serializer = disable_serializer_queries(serializer)`. If you're using REST framework generic views, you can also add a view mixin, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer.
 
 #### Escape hatch
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ If you're using the Django `render` shortcut (as in the example above), to avoid
 
 `TemplateResponse` (and `SimpleTemplateResponse`) objects are lazy, meaning that template rendering happens on the way "out" of the Django stack. `zen_queries.TemplateResponse` and `zen_queries.SimpleTemplateResponse` are subclasses of these with `queries_disabled` applied to the `render` method.
 
-#### Serializer mixin
+#### Django REST framework Serializer and View mixins
 
-Django REST framework serializers are another major source of unexpected queries. Adding a field to a serializer (perhaps deep within a tree of nested serializers) can very easily cause your application to suddenly start emitting hundreds of queries. `zen_queries.rest_framework.QueriesDisallowedMixin` can be applied to any serializer to wrap `queries_disabled` around the `.data` property, meaning that the serialization phase is not allowed to execute any queries.
+Django REST framework serializers are another major source of unexpected queries. Adding a field to a serializer (perhaps deep within a tree of nested serializers) can very easily cause your application to suddenly start emitting hundreds of queries. `zen_queries.rest_framework.QueriesDisabledSerializerMixin` can be applied to any serializer to wrap `queries_disabled` around the `.data` property, meaning that the serialization phase is not allowed to execute any queries. You can also add a mixin to your REST framework views, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer.
 
 #### Escape hatch
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ If you're using the Django `render` shortcut (as in the example above), to avoid
 
 #### Django REST framework Serializer and View mixins
 
-Django REST framework serializers are another major source of unexpected queries. Adding a field to a serializer (perhaps deep within a tree of nested serializers) can very easily cause your application to suddenly start emitting hundreds of queries. `zen_queries.rest_framework.QueriesDisabledSerializerMixin` can be added to any serializer to wrap `queries_disabled` around the `.data` property, meaning that the serialization phase is not allowed to execute any queries. You can add this mixin to an existing serializer instance with `zen_queries.rest_framework.disable_serializer_queries` like this: `serializer = disable_serializer_queries(serializer)`. If you're using REST framework generic views, you can also add a view mixin, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer.
+Django REST framework serializers are another major source of unexpected queries. Adding a field to a serializer (perhaps deep within a tree of nested serializers) can very easily cause your application to suddenly start emitting hundreds of queries. `zen_queries.rest_framework.QueriesDisabledSerializerMixin` can be added to any serializer to wrap `queries_disabled` around the `.data` property, meaning that the serialization phase is not allowed to execute any queries.
+
+You can add this mixin to an existing serializer *instance* with `zen_queries.rest_framework.disable_serializer_queries` like this: `serializer = disable_serializer_queries(serializer)`.
+
+If you're using REST framework generic views, you can also add a view mixin, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer. This is useful because you may want to use the same serializer class but only disable queries in some contexts, such as in a list view.
 
 #### Escape hatch
 

--- a/zen_queries/__init__.py
+++ b/zen_queries/__init__.py
@@ -4,7 +4,6 @@ from zen_queries.decorators import (
     QueriesDisabledError,
 )
 from zen_queries.render import render
-from zen_queries.rest_framework import QueriesDisabledSerializerMixin
 from zen_queries.template_response import TemplateResponse, SimpleTemplateResponse
 from zen_queries.utils import fetch
 

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -6,3 +6,14 @@ class QueriesDisabledSerializerMixin(object):
     def data(self):
         with queries_disabled():
             return super(QueriesDisabledSerializerMixin, self).data
+
+
+class QueriesDisabledViewMixin(object):
+    def get_serializer(self, *args, **kwargs):
+        serializer = super().get_serializer(*args, **kwargs)
+        serializer.__class__ = type(
+            serializer.__class__.__name__,
+            (QueriesDisabledSerializerMixin, serializer.__class__),
+            {},
+        )
+        return serializer

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -8,14 +8,18 @@ class QueriesDisabledSerializerMixin(object):
             return super(QueriesDisabledSerializerMixin, self).data
 
 
+def disable_serializer_queries(serializer):
+    serializer.__class__ = type(
+        serializer.__class__.__name__,
+        (QueriesDisabledSerializerMixin, serializer.__class__),
+        {},
+    )
+    return serializer
+
+
 class QueriesDisabledViewMixin(object):
     def get_serializer(self, *args, **kwargs):
         serializer = super(QueriesDisabledViewMixin, self).get_serializer(
             *args, **kwargs
         )
-        serializer.__class__ = type(
-            serializer.__class__.__name__,
-            (QueriesDisabledSerializerMixin, serializer.__class__),
-            {},
-        )
-        return serializer
+        return disable_serializer_queries(serializer)

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -10,7 +10,9 @@ class QueriesDisabledSerializerMixin(object):
 
 class QueriesDisabledViewMixin(object):
     def get_serializer(self, *args, **kwargs):
-        serializer = super().get_serializer(*args, **kwargs)
+        serializer = super(QueriesDisabledViewMixin, self).get_serializer(
+            *args, **kwargs
+        )
         serializer.__class__ = type(
             serializer.__class__.__name__,
             (QueriesDisabledSerializerMixin, serializer.__class__),

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -4,10 +4,13 @@ from zen_queries import (
     queries_disabled,
     queries_dangerously_enabled,
     QueriesDisabledError,
-    QueriesDisabledSerializerMixin,
     render,
     SimpleTemplateResponse,
     TemplateResponse,
+)
+from zen_queries.rest_framework import (
+    QueriesDisabledSerializerMixin,
+    QueriesDisabledViewMixin,
 )
 from zen_queries.tests.models import Widget
 
@@ -105,3 +108,21 @@ class SerializerMixinTestCase(TestCase):
         serializer = QueriesDisabledSerializer(widgets)
         with self.assertRaises(QueriesDisabledError):
             serializer.data
+
+
+class FakeView(object):
+    def get_serializer(self, *args, **kwargs):
+        return FakeSerializer(Widget.objects.all())
+
+    def get(self):
+        return self.get_serializer().data
+
+
+class QueriesDisabledView(QueriesDisabledViewMixin, FakeView):
+    pass
+
+
+class RESTFrameworkViewMixinTestCase(TestCase):
+    def test_view_mixin(self):
+        with self.assertRaises(QueriesDisabledError):
+            QueriesDisabledView().get()

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -9,6 +9,7 @@ from zen_queries import (
     TemplateResponse,
 )
 from zen_queries.rest_framework import (
+    disable_serializer_queries,
     QueriesDisabledSerializerMixin,
     QueriesDisabledViewMixin,
 )
@@ -106,6 +107,13 @@ class SerializerMixinTestCase(TestCase):
     def test_serializer_mixin(self):
         widgets = Widget.objects.all()
         serializer = QueriesDisabledSerializer(widgets)
+        with self.assertRaises(QueriesDisabledError):
+            serializer.data
+
+    def test_add_mixin_to_instance(self):
+        widgets = Widget.objects.all()
+        serializer = FakeSerializer(widgets)
+        serializer = disable_serializer_queries(serializer)
         with self.assertRaises(QueriesDisabledError):
             serializer.data
 


### PR DESCRIPTION
This adds a `QueriesDisabledViewMixin` for REST framework views that automagically applies the serializer mixin to the serializer attached to the view. This is much nicer than applying it directly to the serializer, as the serializer might be used in multiple places, so this allows you to start using `zen-queries` on a view-by-view basis.

I've also moved the REST framework mixins out of the global `zen_queries` namespace for clarity - you now have to import from `zen_queries.rest_framework`.