### PR TITLE
Tidy up .travis.yml and run black check on Python 3.7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       env: 'DJANGO_VERSION=2.1'
 install:
   - pip install -U django==$DJANGO_VERSION
-  - '[[ "$TRAVIS_PYTHON_VERSION" = "3.7" ]] && pip install black'
+  - 'if [ "$TRAVIS_PYTHON_VERSION" = "3.7" ]; then pip install black; fi'
 script:
   - python manage.py test
-  - '[[ "$TRAVIS_PYTHON_VERSION" = "3.7" ]] && black --check zen_queries'
+  - 'if [ "$TRAVIS_PYTHON_VERSION" = "3.7" ]; then black --check zen_queries; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: python
 sudo: required
 dist: xenial
 python:
-- '2.7'
-- '3.5'
-- '3.6'
-- '3.7'
+  - '2.7'
+  - '3.5'
+  - '3.6'
+  - '3.7'
 env:
-- DJANGO_VERSION=1.8
-- DJANGO_VERSION=1.11
-- DJANGO_VERSION=2.0
-- DJANGO_VERSION=2.1
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.11
+  - DJANGO_VERSION=2.0
+  - DJANGO_VERSION=2.1
 matrix:
   exclude:
     - python: '2.7'
@@ -18,5 +18,8 @@ matrix:
     - python: '2.7'
       env: 'DJANGO_VERSION=2.1'
 install:
-- pip install -U django==$DJANGO_VERSION
-script: python manage.py test
+  - pip install -U django==$DJANGO_VERSION
+  - '[[ "$TRAVIS_PYTHON_VERSION" = "3.7" ]] && pip install black'
+script:
+  - python manage.py test
+  - '[[ "$TRAVIS_PYTHON_VERSION" = "3.7" ]] && black --check zen_queries'


### PR DESCRIPTION
Black only works on Python 3.6+, and only really needs to be run once anyway. So just running it in one row of the build matrix.