### PR TITLE
Only disable queries on GET requests when using the serializer mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Django REST framework serializers are another major source of unexpected queries
 
 You can add this mixin to an existing serializer *instance* with `zen_queries.rest_framework.disable_serializer_queries` like this: `serializer = disable_serializer_queries(serializer)`.
 
-If you're using REST framework generic views, you can also add a view mixin, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer. This is useful because you may want to use the same serializer class but only disable queries in some contexts, such as in a list view.
+If you're using REST framework generic views, you can also add a view mixin, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer. This is useful because you may want to use the same serializer class but only disable queries in some contexts, such as in a list view. Note that the view mixin only disables queries on `GET` requests. Bear in mind that this approach is quite high-level and may not work as expected in certain circumstances. It's usually more explicit to use the serializer mixin instead.
 
 #### Escape hatch
 
@@ -146,7 +146,7 @@ Probably best not to ask.
 Install from PyPI
 
     pip install django-zen-queries
-    
+
 ## Code of conduct
 
 For guidelines regarding the code of conduct when contributing to this repository please review [https://www.dabapps.com/open-source/code-of-conduct/](https://www.dabapps.com/open-source/code-of-conduct/)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Django REST framework serializers are another major source of unexpected queries
 
 You can add this mixin to an existing serializer *instance* with `zen_queries.rest_framework.disable_serializer_queries` like this: `serializer = disable_serializer_queries(serializer)`.
 
-If you're using REST framework generic views, you can also add a view mixin, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer. This is useful because you may want to use the same serializer class but only disable queries in some contexts, such as in a list view. Note that the view mixin only disables queries on `GET` requests. Bear in mind that this approach is quite high-level and may not work as expected in certain circumstances. It's usually more explicit to use the serializer mixin instead.
+If you're using REST framework generic views, you can also add a view mixin, `zen_queries.rest_framework.QueriesDisabledViewMixin`, which overrides `get_serializer` to mix the `QueriesDisabledSerializerMixin` into your existing serializer. This is useful because you may want to use the same serializer class between multiple views but only disable queries in some contexts, such as in a list view.  Remember that Python MRO is left-right, so the mixin must come before (to the left of) any base classes that implement `get_serializer`. The view mixin only disables queries on `GET` requests, so can safely be used with `ListCreateAPIView` and similar.
 
 #### Escape hatch
 

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -22,4 +22,6 @@ class QueriesDisabledViewMixin(object):
         serializer = super(QueriesDisabledViewMixin, self).get_serializer(
             *args, **kwargs
         )
-        return disable_serializer_queries(serializer)
+        if self.request.method == 'GET':
+            serializer = disable_serializer_queries(serializer)
+        return serializer

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -22,6 +22,6 @@ class QueriesDisabledViewMixin(object):
         serializer = super(QueriesDisabledViewMixin, self).get_serializer(
             *args, **kwargs
         )
-        if self.request.method == 'GET':
+        if self.request.method == "GET":
             serializer = disable_serializer_queries(serializer)
         return serializer

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -139,7 +139,7 @@ class QueriesDisabledView(QueriesDisabledViewMixin, FakeView):
 class RESTFrameworkViewMixinTestCase(TestCase):
     def test_view_mixin(self):
         with self.assertRaises(QueriesDisabledError):
-            QueriesDisabledView().handle_request(method='GET')
+            QueriesDisabledView().handle_request(method="GET")
 
     def test_post_ignored(self):
-        QueriesDisabledView().handle_request(method='POST')
+        QueriesDisabledView().handle_request(method="POST")

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -118,11 +118,17 @@ class SerializerMixinTestCase(TestCase):
             serializer.data
 
 
+class FakeRequest(object):
+    def __init__(self, method):
+        self.method = method
+
+
 class FakeView(object):
     def get_serializer(self, *args, **kwargs):
         return FakeSerializer(Widget.objects.all())
 
-    def get(self):
+    def handle_request(self, method):
+        self.request = FakeRequest(method)
         return self.get_serializer().data
 
 
@@ -133,4 +139,7 @@ class QueriesDisabledView(QueriesDisabledViewMixin, FakeView):
 class RESTFrameworkViewMixinTestCase(TestCase):
     def test_view_mixin(self):
         with self.assertRaises(QueriesDisabledError):
-            QueriesDisabledView().get()
+            QueriesDisabledView().handle_request(method='GET')
+
+    def test_post_ignored(self):
+        QueriesDisabledView().handle_request(method='POST')


### PR DESCRIPTION
This addresses the issue that mixing in the `QueriesDisabledViewMixin` on a `ListCreateAPIView` (say) causes queries to be disabled on creates - which we don't want.

This is a simple patch but not sure if there's a better way to achieve this.. 