### PR TITLE
Include SQL in exceptions

### DIFF
--- a/zen_queries/decorators.py
+++ b/zen_queries/decorators.py
@@ -7,6 +7,8 @@ class QueriesDisabledError(Exception):
 
 
 class QueriesDisabledCursor:
+    query = None
+
     def execute(self, sql, *args, **kwargs):
         raise QueriesDisabledError(sql)
 

--- a/zen_queries/decorators.py
+++ b/zen_queries/decorators.py
@@ -6,14 +6,25 @@ class QueriesDisabledError(Exception):
     pass
 
 
-def _fake(*args, **kwargs):
-    raise QueriesDisabledError()
+class QueriesDisabledCursor:
+    def execute(self, sql, *args, **kwargs):
+        raise QueriesDisabledError(sql)
+
+    def executemany(self, sql, *args, **kwargs):
+        raise QueriesDisabledError(sql)
+
+    def close(self):
+        pass
+
+
+def _create_queries_disabled_cursor(*args, **kwargs):
+    return QueriesDisabledCursor()
 
 
 def _apply_monkeypatch(connection):
     connection._queries_disabled = True
     connection._real_create_cursor = connection.create_cursor
-    connection.create_cursor = _fake
+    connection.create_cursor = _create_queries_disabled_cursor
 
 
 def _remove_monkeypatch(connection):

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -60,6 +60,14 @@ class ContextManagerTestCase(TestCase):
                 Widget.objects.count()
         Widget.objects.count()
 
+    def test_sql_in_exception(self):
+        queryset = Widget.objects.all()
+        with queries_disabled():
+            try:
+                fetch(queryset)
+            except QueriesDisabledError as e:
+                self.assertEqual(str(e), str(queryset.query))
+
 
 class FetchTestCase(TestCase):
     def test_fetch_all(self):


### PR DESCRIPTION
Fixes #14 

Rather than raising when `connection.create_cursor` is called, we now return a fake cursor which implements just enough of the [DBAPI cursor methods](https://www.python.org/dev/peps/pep-0249/#cursor-methods) to allow Django to get to the point of trying to execute the query before raising the exception. This means we can now include the SQL that was going to be executed in the exception.