### PR TITLE
Install Django REST framework during test runs, not on package installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install package
       run: pip install -e .
     - name: Install dependencies
-      run: pip install -U django==${{ matrix.django }} black
+      run: pip install -U django==${{ matrix.django }} black djangorestframework
     - name: Run tests
       run: python manage.py test
     - name: Run black

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "Django>=2.2",
-        "djangorestframework>=3.6.0"
     ],
     project_urls={
         "Changelog": "https://github.com/dabapps/django-zen-queries/releases",


### PR DESCRIPTION
This removes the dependency on `djangorestframework` for actually using zen-queries (you still need it to run the tests).