### PR TITLE
Remove the Travis CI build status badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 django-zen-queries
 ====================
 
+![Build Status](https://github.com/dabapps/django-zen-queries/workflows/CI/badge.svg)
 [![pypi release](https://img.shields.io/pypi/v/django-zen-queries.svg)](https://pypi.python.org/pypi/django-zen-queries)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 django-zen-queries
 ====================
 
-[![Build Status](https://travis-ci.com/dabapps/django-zen-queries.svg?branch=master)](https://travis-ci.com/dabapps/django-zen-queries)
 [![pypi release](https://img.shields.io/pypi/v/django-zen-queries.svg)](https://pypi.python.org/pypi/django-zen-queries)
 
 


### PR DESCRIPTION
... and replace with the GitHub Actions equivalent.

![Build Status](https://github.com/dabapps/django-zen-queries/workflows/CI/badge.svg)
