### PR TITLE
Only force evaluate serializer instance if it's a queryset

### DIFF
--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -1,5 +1,6 @@
 from zen_queries import queries_disabled
 from zen_queries.utils import fetch
+from django.db.models import QuerySet
 
 
 class QueriesDisabledSerializerMixin:
@@ -32,7 +33,9 @@ class QueriesDisabledViewMixin(object):
         )
         if self.request.method == "GET":
             serializer = disable_serializer_queries(serializer)
-            if getattr(serializer, "many", False):
+            if getattr(serializer, "many", False) and isinstance(
+                serializer.instance, QuerySet
+            ):
                 # Serializer data must be fully evaluated prior to serialization. See #18.
                 fetch(serializer.instance)
         return serializer

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -33,9 +33,7 @@ class QueriesDisabledViewMixin(object):
         )
         if self.request.method == "GET":
             serializer = disable_serializer_queries(serializer)
-            if getattr(serializer, "many", False) and isinstance(
-                serializer.instance, QuerySet
-            ):
+            if isinstance(serializer.instance, QuerySet):
                 # Serializer data must be fully evaluated prior to serialization. See #18.
                 fetch(serializer.instance)
         return serializer

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -148,6 +148,15 @@ class QueriesDisabledView(QueriesDisabledViewMixin, FakeView):
     pass
 
 
+class FakeListView(FakeView):
+    def get_serializer(self, *args, **kwargs):
+        return WidgetSerializer(list(Widget.objects.all()), many=True)
+
+
+class QueriesDisabledListView(QueriesDisabledViewMixin, FakeListView):
+    pass
+
+
 class RESTFrameworkViewMixinTestCase(TestCase):
     def test_view_mixin(self):
         view = QueriesDisabledView()
@@ -160,5 +169,12 @@ class RESTFrameworkViewMixinTestCase(TestCase):
         view = QueriesDisabledView()
         view.handle_request(method="POST")
         self.assertFalse(
+            isinstance(view.get_serializer(), QueriesDisabledSerializerMixin)
+        )
+
+    def test_serializer_with_list(self):
+        view = QueriesDisabledListView()
+        view.handle_request(method="GET")
+        self.assertTrue(
             isinstance(view.get_serializer(), QueriesDisabledSerializerMixin)
         )


### PR DESCRIPTION
Serializers can be called with things which aren't querysets, specifically lists. In these cases, it's unnecessary to try and forcefully evaluate them, so they can be ignored.

Fixes bug introduced in #27.