### PR TITLE
Add Django 3.2 to test matrix and add new setting to suppress warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
-        django: [2.2, 3.0, 3.1, 3.2rc1]
+        django: [2.2, 3.0, 3.1, 3.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
-        django: [2.2, 3.0, 3.1]
+        django: [2.2, 3.0, 3.1, 3.2rc1]
 
     steps:
     - uses: actions/checkout@v2

--- a/zen_queries/tests/settings.py
+++ b/zen_queries/tests/settings.py
@@ -7,3 +7,5 @@ TEMPLATES = [
 ]
 
 SECRET_KEY = "abcde12345"
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
No need to create a release once this is merged as it only affects CI config and test code.