### PR TITLE
Add template tags to enable or disable queries directly in Django templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,36 @@ If you're using REST framework generic views, you can also add a view mixin, `ze
 
 If you absolutely definitely can't avoid running a query in a part of your codebase that's being executed under a `queries_disabled` block, there is another context manager called `queries_dangerously_enabled` which allows you to temporarily re-enable database queries.
 
+#### Template Tags
+
+Block tags for Django's template system are provided which allow you to enable or disable query execution directly in your templates.
+
+**Important note: In order to use the template libary, you must add `"zen_queries"` to your `INSTALLED_APPS` setting.** Then, use `{% load zen_queries %}` at the top of your template to load the tag library.
+
+The `{% queries_disabled}` tag is most useful if you wish to apply `django-zen-queries` patterns to a third-party library which provides customisation via overriding templates, such as the Django admin.
+
+```jinja2
+{% load zen_queries %}
+
+{% queries_disabled %}
+<ul>
+{% for pizza in pizzas %}
+  <li>{{ pizza.name }}</li>
+{% endfor %}
+</ul>
+{% end_queries_disabled %}
+```
+
+The `{% queries_dangerously_enabled %}` tag is handy if you are using the `render` shortcut or `TemplateResponse` subclass (see above) but wish to allow particular parts of your templates to execute queries. This should be used with caution, and you should wrap only the smallest possible sections of your template: the precise line or lines that need to execute the queries.
+
+```jinja2
+{% load zen_queries %}
+
+{% queries_dangerously_enabled %}
+There are {{ pizzas.count }} pizzas.
+{% end_queries_dangerously_enabled %}
+```
+
 ### Permissions gotcha
 
 Accessing permissions in your templates (via the `{{ perms }}` template variable) can be a source of queries at template-render time. Fortunately, Django's permission checks are [cached by the `ModelBackend`](https://docs.djangoproject.com/en/2.2/topics/auth/default/#permission-caching), which can be pre-populated by calling `request.user.get_all_permissions()` in the view, before rendering the template.

--- a/zen_queries/templatetags/zen_queries.py
+++ b/zen_queries/templatetags/zen_queries.py
@@ -5,21 +5,22 @@ import zen_queries
 register = Library()
 
 
-class RenderNodelistWithContextManagerNode(Node):
+class QueriesDisabledNode(Node):
     def __init__(self, nodelist):
         self.nodelist = nodelist
 
     def render(self, context):
-        with self.context_manager:
+        with zen_queries.queries_disabled():
             return self.nodelist.render(context)
 
 
-class QueriesDisabledNode(RenderNodelistWithContextManagerNode):
-    context_manager = zen_queries.queries_disabled()
+class QueriesDangerouslyEnabledNode(Node):
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
 
-
-class QueriesDangerouslyEnabledNode(RenderNodelistWithContextManagerNode):
-    context_manager = zen_queries.queries_dangerously_enabled()
+    def render(self, context):
+        with zen_queries.queries_dangerously_enabled():
+            return self.nodelist.render(context)
 
 
 @register.tag

--- a/zen_queries/templatetags/zen_queries.py
+++ b/zen_queries/templatetags/zen_queries.py
@@ -1,0 +1,36 @@
+from django.template import Library, Node
+import zen_queries
+
+
+register = Library()
+
+
+class RenderNodelistWithContextManagerNode(Node):
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
+
+    def render(self, context):
+        with self.context_manager:
+            return self.nodelist.render(context)
+
+
+class QueriesDisabledNode(RenderNodelistWithContextManagerNode):
+    context_manager = zen_queries.queries_disabled()
+
+
+class QueriesDangerouslyEnabledNode(RenderNodelistWithContextManagerNode):
+    context_manager = zen_queries.queries_dangerously_enabled()
+
+
+@register.tag
+def queries_disabled(parser, token):
+    nodelist = parser.parse(("end_queries_disabled",))
+    parser.delete_first_token()
+    return QueriesDisabledNode(nodelist)
+
+
+@register.tag
+def queries_dangerously_enabled(parser, token):
+    nodelist = parser.parse(("end_queries_dangerously_enabled",))
+    parser.delete_first_token()
+    return QueriesDangerouslyEnabledNode(nodelist)

--- a/zen_queries/tests/settings.py
+++ b/zen_queries/tests/settings.py
@@ -1,6 +1,6 @@
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
-INSTALLED_APPS = ["zen_queries.tests"]
+INSTALLED_APPS = ["zen_queries", "zen_queries.tests"]
 
 TEMPLATES = [
     {"BACKEND": "django.template.backends.django.DjangoTemplates", "APP_DIRS": True}

--- a/zen_queries/tests/templates/queries_dangerously_enabled_tag.html
+++ b/zen_queries/tests/templates/queries_dangerously_enabled_tag.html
@@ -1,0 +1,5 @@
+{% load zen_queries %}
+
+{% queries_dangerously_enabled %}
+{{ widgets.count }}
+{% end_queries_dangerously_enabled %}

--- a/zen_queries/tests/templates/queries_disabled_tag.html
+++ b/zen_queries/tests/templates/queries_disabled_tag.html
@@ -1,0 +1,5 @@
+{% load zen_queries %}
+
+{% queries_disabled %}
+{{ widgets.count }}
+{% end_queries_disabled %}

--- a/zen_queries/tests/tests.py
+++ b/zen_queries/tests/tests.py
@@ -1,3 +1,4 @@
+from django.shortcuts import render as django_render
 from django.test import TestCase
 from zen_queries import (
     fetch,
@@ -104,6 +105,17 @@ class TemplateResponseTestCase(TestCase):
         response = TemplateResponse(None, "template.html", {"widgets": widgets})
         with self.assertRaises(QueriesDisabledError):
             response.render()
+
+
+class TemplateTagTestCase(TestCase):
+    def test_queries_disabled_template_tag(self):
+        widgets = Widget.objects.all()
+        with self.assertRaises(QueriesDisabledError):
+            django_render(None, "queries_disabled_tag.html", {"widgets": widgets})
+
+    def test_queries_dangerously_enabled_template_tag(self):
+        widgets = Widget.objects.all()
+        render(None, "queries_dangerously_enabled_tag.html", {"widgets": widgets})
 
 
 class WidgetSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This PR adds a Django template library containing two block tags, `{% queries_disabled %}` and `{% queries_dangerously_enabled %}`. See the README diff for details.