### PR TITLE
Type hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
     - name: Install package
       run: pip install -e .
     - name: Install dependencies
-      run: pip install -U django==${{ matrix.django }} black djangorestframework pytz
+      run: pip install -U django==${{ matrix.django }} black djangorestframework mypy pytz
     - name: Run tests
       run: python manage.py test
     - name: Run black
       run: black --check zen_queries
+    - name: Run mypy
+      run: mypy zen_queries

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,12 @@ def get_package_data(package):
 
     filepaths = []
     for base, filenames in walk:
+        if "__pycache__" in base:
+            continue
+        if base.startswith(".mypy_cache"):
+            continue
         filepaths.extend([os.path.join(base, filename) for filename in filenames])
+    filepaths.append("py.typed")
     return {package: filepaths}
 
 
@@ -86,5 +91,5 @@ setup(
     project_urls={
         "Changelog": "https://github.com/dabapps/django-zen-queries/releases",
         "Issues": "https://github.com/dabapps/django-zen-queries/issues",
-    }
+    },
 )

--- a/zen_queries/__init__.py
+++ b/zen_queries/__init__.py
@@ -9,3 +9,13 @@ from zen_queries.utils import fetch
 
 
 __version__ = "2.1.0"
+
+__all__ = [
+    "fetch",
+    "queries_dangerously_enabled",
+    "queries_disabled",
+    "QueriesDisabledError",
+    "render",
+    "SimpleTemplateResponse",
+    "TemplateResponse",
+]

--- a/zen_queries/decorators.py
+++ b/zen_queries/decorators.py
@@ -1,47 +1,56 @@
 from contextlib import contextmanager
 from django.db import connections
+from typing import Any, Callable, Dict, Generator
 
 
 class QueriesDisabledError(Exception):
     pass
 
 
-def _raise_exception(execute, sql, params, many, context):
+def _raise_exception(
+    execute: Callable[[str, Any, bool, Dict[str, Any]], Any],
+    sql: str,
+    params: Any,
+    many: bool,
+    context: Dict[str, Any],
+) -> Any:
     raise QueriesDisabledError(sql)
 
 
-def _disable_queries():
+def _disable_queries() -> None:
     for connection in connections.all():
         connection.execute_wrappers.append(_raise_exception)
 
 
-def _enable_queries():
+def _enable_queries() -> None:
     for connection in connections.all():
         connection.execute_wrappers.pop()
 
 
-def _are_queries_disabled():
+def _are_queries_disabled() -> bool:
     for connection in connections.all():
         return _raise_exception in connection.execute_wrappers
+    return False
 
 
-def _are_queries_dangerously_enabled():
+def _are_queries_dangerously_enabled() -> bool:
     for connection in connections.all():
         return hasattr(connection, "_queries_dangerously_enabled")
+    return False
 
 
-def _mark_as_dangerously_enabled():
+def _mark_as_dangerously_enabled() -> None:
     for connection in connections.all():
         connection._queries_dangerously_enabled = True
 
 
-def _mark_as_not_dangerously_enabled():
+def _mark_as_not_dangerously_enabled() -> None:
     for connection in connections.all():
         del connection._queries_dangerously_enabled
 
 
 @contextmanager
-def queries_disabled():
+def queries_disabled() -> Generator[None, None, None]:
     queries_already_disabled = _are_queries_disabled()
     if not queries_already_disabled and not _are_queries_dangerously_enabled():
         _disable_queries()
@@ -53,7 +62,7 @@ def queries_disabled():
 
 
 @contextmanager
-def queries_dangerously_enabled():
+def queries_dangerously_enabled() -> Generator[None, None, None]:
     queries_dangerously_enabled_before = _are_queries_dangerously_enabled()
     if not queries_dangerously_enabled_before:
         _mark_as_dangerously_enabled()

--- a/zen_queries/render.py
+++ b/zen_queries/render.py
@@ -1,12 +1,28 @@
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render as django_render
+from typing import Any, Mapping, Optional, Sequence, Union
 from zen_queries import queries_disabled
 
 
-def render(*args, **kwargs):
+def render(
+    request: HttpRequest,
+    template_name: Union[str, Sequence[str]],
+    context: Optional[Mapping[str, Any]] = None,
+    content_type: Optional[str] = None,
+    status: Optional[int] = None,
+    using: Optional[str] = None,
+) -> HttpResponse:
     """
     Wrapper around Django's `render` shortcut that is
     not allowed to run database queries
     """
     with queries_disabled():
-        response = django_render(*args, **kwargs)
+        response = django_render(
+            request,
+            template_name,
+            context=context,
+            content_type=content_type,
+            status=status,
+            using=using,
+        )
     return response

--- a/zen_queries/rest_framework.py
+++ b/zen_queries/rest_framework.py
@@ -14,7 +14,7 @@ class QueriesDisabledSerializerMixin:
     @property
     def data(self):
         with queries_disabled():
-            return super(QueriesDisabledSerializerMixin, self).data
+            return super().data
 
 
 def disable_serializer_queries(serializer):
@@ -26,9 +26,9 @@ def disable_serializer_queries(serializer):
     return serializer
 
 
-class QueriesDisabledViewMixin(object):
+class QueriesDisabledViewMixin:
     def get_serializer(self, *args, **kwargs):
-        serializer = super(QueriesDisabledViewMixin, self).get_serializer(
+        serializer = super().get_serializer(
             *args, **kwargs
         )
         if self.request.method == "GET":

--- a/zen_queries/template_response.py
+++ b/zen_queries/template_response.py
@@ -5,10 +5,10 @@ from django.template.response import (
 from zen_queries import queries_disabled
 
 
-class RenderMixin(object):
+class RenderMixin:
     def render(self, *args, **kwargs):
         with queries_disabled():
-            return super(RenderMixin, self).render(*args, **kwargs)
+            return super().render(*args, **kwargs)
 
 
 class TemplateResponse(RenderMixin, DjangoTemplateResponse):

--- a/zen_queries/template_response.py
+++ b/zen_queries/template_response.py
@@ -6,9 +6,9 @@ from zen_queries import queries_disabled
 
 
 class RenderMixin:
-    def render(self, *args, **kwargs):
+    def render(self) -> DjangoSimpleTemplateResponse:
         with queries_disabled():
-            return super().render(*args, **kwargs)
+            return super().render()  # type: ignore
 
 
 class TemplateResponse(RenderMixin, DjangoTemplateResponse):

--- a/zen_queries/utils.py
+++ b/zen_queries/utils.py
@@ -1,3 +1,9 @@
-def fetch(queryset):
-    queryset._fetch_all()
+from django.db.models.query import QuerySet
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def fetch(queryset: T) -> T:
+    queryset._fetch_all()  # type: ignore
     return queryset


### PR DESCRIPTION
I've just started using django-zen-queries on a new Django app and are very happy so far, as this is easy to introduce when doing it early on and provides some good discipline.

To avoid having to wrap all call to `render()` with a context manager, I'm using the alternative `zen_queries.render()` function. I'm also using [django-stubs](https://github.com/typeddjango/django-stubs) to add type hints to Django and run with a quite strict mypy config. When migrating to django-zen-queries, I got a new typing issue because the return value from `zen_queries.render()` is untyped. In addition, my IDE cannot provide help with what arguments are accepted by `zen_queries.render()` because it just accepts and passes on `*args` and `**kwargs`.

This PR adds type hints to django-zen-queries (except the `zen_queries.rest_framework` module, which I haven't used yet). Where the type hints are non-trivial, they've been lifted directly from django-stubs 1.9.0.