### PR TITLE
Added settings to be able to globally disable zen queries

### DIFF
--- a/zen_queries/decorators.py
+++ b/zen_queries/decorators.py
@@ -45,6 +45,7 @@ def _mark_as_not_dangerously_enabled():
 def queries_disabled():
     if not settings.ZEN_QUERIES_ENABLED:
         yield
+        return
     queries_already_disabled = _are_queries_disabled()
     if not queries_already_disabled and not _are_queries_dangerously_enabled():
         _disable_queries()
@@ -59,6 +60,7 @@ def queries_disabled():
 def queries_dangerously_enabled():
     if not settings.ZEN_QUERIES_ENABLED:
         yield
+        return
     queries_dangerously_enabled_before = _are_queries_dangerously_enabled()
     if not queries_dangerously_enabled_before:
         _mark_as_dangerously_enabled()

--- a/zen_queries/decorators.py
+++ b/zen_queries/decorators.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from django.db import connections
-from django.conf import settings
+from zen_queries import settings
 
 
 class QueriesDisabledError(Exception):

--- a/zen_queries/decorators.py
+++ b/zen_queries/decorators.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from django.db import connections
+from django.conf import settings
 
 
 class QueriesDisabledError(Exception):
@@ -42,6 +43,8 @@ def _mark_as_not_dangerously_enabled():
 
 @contextmanager
 def queries_disabled():
+    if not settings.ZEN_QUERIES_ENABLED:
+        yield
     queries_already_disabled = _are_queries_disabled()
     if not queries_already_disabled and not _are_queries_dangerously_enabled():
         _disable_queries()
@@ -54,6 +57,8 @@ def queries_disabled():
 
 @contextmanager
 def queries_dangerously_enabled():
+    if not settings.ZEN_QUERIES_ENABLED:
+        yield
     queries_dangerously_enabled_before = _are_queries_dangerously_enabled()
     if not queries_dangerously_enabled_before:
         _mark_as_dangerously_enabled()

--- a/zen_queries/settings.py
+++ b/zen_queries/settings.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+ZEN_QUERIES_ENABLED = getattr(settings, 'ZEN_QUERIES_ENABLED', True)


### PR DESCRIPTION
The motivation is that I don't want to crash the production website in case of an unwanted query, but I want to have it enabled everywhere else.
The default is True for backward compatibility.